### PR TITLE
Fixed IniParserAdapter.Read() compatibility issue

### DIFF
--- a/IniWrapper.ini-parser/IniWrapper.ini-parser/IniParserAdapter.cs
+++ b/IniWrapper.ini-parser/IniWrapper.ini-parser/IniParserAdapter.cs
@@ -1,4 +1,5 @@
-﻿using IniParser;
+﻿using System.Text;
+using IniParser;
 using IniParser.Model;
 using IniWrapper.ParserWrapper;
 using IniWrapper.Settings;
@@ -22,6 +23,25 @@ namespace IniWrapper.ini_parser
         public string Read(string section, string key)
         {
             ReadFromFile();
+
+            // If no key has been specified, all key-value pairs (separated by \0) from the given section need to be returned.
+            if (string.IsNullOrEmpty(key))
+            {
+                var sb = new StringBuilder();
+                var sectionDataCollection = _iniReadData.Sections[section];
+
+                if (sectionDataCollection != null)
+                {
+                    foreach (var sec in sectionDataCollection)
+                    {
+                        sb.Append($"{sec.KeyName}={sec.Value}\0");
+                    }
+                }
+
+                var result = sb.ToString().Trim('\0');
+                return result;
+            }
+
             return _iniReadData[section][key];
         }
 


### PR DESCRIPTION
The default ini parser from the IniWrapper returns a list of all key-value pairs when data is read without specifying a key (see [IniParser.cs](https://github.com/Szpi/IniWrapper/blob/master/IniWrapper/IniWrapper/ParserWrapper/IniParser.cs)). 
This behavior is required for IniWrapper to work properly (for example when properties of type List<MyType> are deserialized).
The IniParserAdapter currently fails with a ArgumentNullException. This has been fixed.